### PR TITLE
Add tarball for pjproject 2.10

### DIFF
--- a/pjproject/2.10/MD5SUM.TXT
+++ b/pjproject/2.10/MD5SUM.TXT
@@ -1,0 +1,1 @@
+56916ac262440bdd4673399f54e2f32a  pjproject-2.10.tar.bz2


### PR DESCRIPTION
Because they have moved their releases to GitHub, I had to to re-roll the .tar.gz as a .tar.bz2 to not break everything. Also needed to create MD5SUM.TXT "by hand."